### PR TITLE
Remove scrollbars from document overflow by adding `box-sizing: border-box`

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,14 +6,16 @@
     <title>Ottawa Restaurants</title>
     <script type="module" src="dist/mapml-viewer.js"></script>
      <style> 
-       html, 
-       body { 
-         height: 100%; 
-       } 
-       * { 
-         margin: 0; 
-         padding: 0; 
-       } 
+       html,
+       body {
+         height: 100%;
+       }
+       body {
+         margin: 0;
+       }
+       *, ::before, ::after {
+         box-sizing: border-box;
+       }
         
        /* Specifying the `:defined` selector is recommended to style the map 
        element, such that styles don't apply when fallback content is in use 


### PR DESCRIPTION
Requested in https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/350.