### PR TITLE
Remove aggressive `padding` and `margin` reset

### DIFF
--- a/painting/index.html
+++ b/painting/index.html
@@ -9,11 +9,7 @@
           html, 
           body { 
             height: 100%; 
-          } 
-          * { 
-            margin: 0; 
-            padding: 0; 
-          } 
+          }
 
           /* Specifying the `:defined` selector is recommended to style the map 
           element, such that styles don't apply when fallback content is in use 


### PR DESCRIPTION
Fixes the issues described by @prushforth in https://github.com/Maps4HTML/experiments/pull/34#issue-626141086.