### PR TITLE
Add global style sheet

### DIFF
--- a/api/custom-map-ui/bootstrap-ui.html
+++ b/api/custom-map-ui/bootstrap-ui.html
@@ -1,37 +1,15 @@
 <!DOCTYPE html>
-<html>
-
+<html lang="en">
 <head>
-  <title>Using Bootstrap</title>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Using Bootstrap</title>
   <script type="module" src="../../dist/mapml-viewer.js"></script>
+  <link rel="stylesheet" href="../../global.css">
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
     integrity="sha384-JcKb8q3iqJ61gNV9KGb8thSsNjpSL0n8PARn9HuZOnIxN0hoP+VmmDGMN5t9UJ0Z" crossorigin="anonymous">
   <script type="text/javascript" src="./custom-ui.js"></script>
   <style>
-    html {
-      height: 100%
-    }
-
-    body,
-    * {
-      margin: 0;
-      padding: 0;
-    }
-
-    mapml-viewer:defined {
-      /* Responsive map. */
-      max-width: 100%;
-
-      /* Full viewport. */
-      width: 100%;
-      height: 100%;
-
-      /* Remove default (native-like) border. */
-      /* border: none; */
-    }
-
-
     figure {
       display: table;
       position: relative;

--- a/api/custom-map-ui/custom-css-ui.html
+++ b/api/custom-map-ui/custom-css-ui.html
@@ -1,37 +1,15 @@
 <!DOCTYPE html>
-<html>
-
+<html lang="en">
 <head>
-  <title>Using Bootstrap</title>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Using Bootstrap</title>
   <script type="module" src="../../dist/mapml-viewer.js"></script>
+  <link rel="stylesheet" href="../../global.css">
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
     integrity="sha384-JcKb8q3iqJ61gNV9KGb8thSsNjpSL0n8PARn9HuZOnIxN0hoP+VmmDGMN5t9UJ0Z" crossorigin="anonymous">
   <script type="text/javascript" src="./custom-ui.js"></script>
   <style>
-    html {
-      height: 100%
-    }
-
-    body,
-    * {
-      margin: 0;
-      padding: 0;
-    }
-
-    mapml-viewer:defined {
-      /* Responsive map. */
-      max-width: 100%;
-
-      /* Full viewport. */
-      width: 100%;
-      height: 100%;
-
-      /* Remove default (native-like) border. */
-      /* border: none; */
-    }
-
-
     figure {
       display: table;
       position: relative;

--- a/api/custom-map-ui/index.html
+++ b/api/custom-map-ui/index.html
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
-<html>
-
+<html lang="en">
 <head>
-  <title>custom-ui home</title>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>custom-ui home</title>
   <script type="module" src="../../dist/mapml-viewer.js"></script>
+  <link rel="stylesheet" href="../../global.css">
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
     integrity="sha384-JcKb8q3iqJ61gNV9KGb8thSsNjpSL0n8PARn9HuZOnIxN0hoP+VmmDGMN5t9UJ0Z" crossorigin="anonymous">
   <script type="text/javascript" src="./custom-ui.js"></script>

--- a/change-projection/zoomin-zoomout/mapml-viewer/index.html
+++ b/change-projection/zoomin-zoomout/mapml-viewer/index.html
@@ -5,54 +5,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <title>Change projection at z=9</title>
     <script type="module" src="../../../dist/mapml-viewer.js"></script>
-    <style>
-      html,
-      body {
-        height: 100%;
-      }
-      * {
-        margin: 0;
-        padding: 0;
-      }
-      
-      /* Specifying the `:defined` selector is recommended to style the map
-      element, such that styles don't apply when fallback content is in use
-      (e.g. when scripting is disabled or when custom/built-in elements isn't
-      supported in the browser). */
-      mapml-viewer:defined {
-        /* Responsive map. */
-/*         max-width: 100%; */
-        
-        /* Full viewport. */
-         width: 100%; 
-         height: 100%; 
-        
-        /* Remove default (native-like) border. */
-        /* border: none; */
-      }
-      
-      /* Pre-style to avoid FOUC of inline layer- and fallback content. */
-      mapml-viewer:not(:defined) + img[usemap],
-      mapml-viewer:not(:defined) > :not(area):not(.mapml-web-map) {
-        display: none;
-      }
-      /* Ensure inline layer content is hidden if custom/built-in elements isn't
-      supported, or if javascript is disabled. This needs to be defined separately
-      from the above, because the `:not(:defined)` selector invalidates the entire
-      declaration in browsers that do not support it. */
-      layer- {
-        display: none;
-      }
-    </style>
-    <noscript>
-      <style>
-        /* Ensure client-side image map fallbacks are displayed if custom/built-in
-        elements is supported but javascript is disabled. */
-        map[is="web-map"]:not(:defined) + img[usemap] {
-          display: initial;
-        }
-      </style>
-    </noscript>
+    <link rel="stylesheet" href="../../../global.css">
     <script type="module">
       let customProjectionDefinition = `{
             "projection": "EPSG3573", 

--- a/change-projection/zoomin-zoomout/web-map/index.html
+++ b/change-projection/zoomin-zoomout/web-map/index.html
@@ -5,54 +5,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <title>Change projection at z=9</title>
     <script type="module" src="../../../dist/web-map.js"></script>
-    <style>
-      html,
-      body {
-        height: 100%;
-      }
-      * {
-        margin: 0;
-        padding: 0;
-      }
-      
-      /* Specifying the `:defined` selector is recommended to style the map
-      element, such that styles don't apply when fallback content is in use
-      (e.g. when scripting is disabled or when custom/built-in elements isn't
-      supported in the browser). */
-      map[is="web-map"]:defined {
-        /* Responsive map. */
-/*         max-width: 100%; */
-        
-        /* Full viewport. */
-         width: 100%; 
-         height: 100%; 
-        
-        /* Remove default (native-like) border. */
-         border: none; 
-      }
-      
-      /* Pre-style to avoid FOUC of inline layer- and fallback content. */
-      map[is="web-map"]:not(:defined) + img[usemap],
-      map[is="web-map"]:not(:defined) > :not(area):not(.mapml-web-map) {
-        display: none;
-      }
-      /* Ensure inline layer content is hidden if custom/built-in elements isn't
-      supported, or if javascript is disabled. This needs to be defined separately
-      from the above, because the `:not(:defined)` selector invalidates the entire
-      declaration in browsers that do not support it. */
-      layer- {
-        display: none;
-      }
-    </style>
-    <noscript>
-      <style>
-        /* Ensure client-side image map fallbacks are displayed if custom/built-in
-        elements is supported but javascript is disabled. */
-        map[is="web-map"]:not(:defined) + img[usemap] {
-          display: initial;
-        }
-      </style>
-    </noscript>
+    <link rel="stylesheet" href="../../../global.css">
     <script type="module">
       let customProjectionDefinition = `{
             "projection": "EPSG3573", 

--- a/custom-projections/Arctic-SDI/index.html
+++ b/custom-projections/Arctic-SDI/index.html
@@ -5,52 +5,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <title>Arctic SDI - laea</title>
     <script type="module" src="../../dist/mapml-viewer.js"></script>
-     <style> 
-       html, 
-       body { 
-         height: 100%; 
-       } 
-       * { 
-         margin: 0; 
-         padding: 0; 
-       } 
-        
-       /* Specifying the `:defined` selector is recommended to style the map 
-       element, such that styles don't apply when fallback content is in use 
-       (e.g. when scripting is disabled or when custom/built-in elements isn't 
-       supported in the browser). */ 
-       mapml-viewer:defined { 
-         /* Responsive map. */ 
-          max-width: 100%;  
-          
-          width: 100%;  
-          height: 100%;  
-          
-         /* Remove default (native-like) border. */ 
-         /* border: none; */ 
-       } 
-        
-       /* Pre-style to avoid FOUC of inline layer- and fallback content. */ 
-       mapml-viewer:not(:defined) > * { 
-         display: none; 
-       } 
-       /* Ensure inline layer content is hidden if custom/built-in elements isn't 
-       supported, or if javascript is disabled. This needs to be defined separately 
-       from the above, because the `:not(:defined)` selector invalidates the entire 
-       declaration in browsers that do not support it. */ 
-       layer- { 
-         display: none; 
-       } 
-     </style> 
-     <noscript> 
-       <style> 
-         /* Ensure fallback content (children of the map element) is displayed if 
-         custom/built-in elements is supported but javascript is disabled. */ 
-         mapml-viewer:not(:defined) > :not(layer-) { 
-           display: initial; 
-         } 
-       </style> 
-     </noscript> 
+    <link rel="stylesheet" href="../../global.css">
     <script type="module">
       let map = document.querySelector("mapml-viewer");
       let cProjection = map.defineCustomProjection(`{ "projection": "EPSG3573", "proj4string" : "+proj=laea +lat_0=90 +lon_0=-100 +x_0=0 +y_0=0 +ellps=WGS84 +datum=WGS84 +units=m +no_defs",  "origin" : [-4889334.802955,4889334.802955], "resolutions" : [38197.92815,19098.96407,9549.482037,4774.741019,2387.370509,1193.685255,596.8426273,298.4213137,149.2106568,74.60532841,37.30266421], "bounds" : [[-4594983,4507258],[4655569,-4562485]], "tilesize" : 256 }`);    

--- a/custom-projections/Atlas-of-Canada/index.html
+++ b/custom-projections/Atlas-of-Canada/index.html
@@ -5,53 +5,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <title>Atlas of Canada Azimuthal Equal Distance Wall map</title>
     <script type="module" src="../../dist/mapml-viewer.js"></script>
-     <style> 
-       html, 
-       body { 
-         height: 100%; 
-       } 
-       * { 
-         margin: 0; 
-         padding: 0; 
-       } 
-        
-       /* Specifying the `:defined` selector is recommended to style the map 
-       element, such that styles don't apply when fallback content is in use 
-       (e.g. when scripting is disabled or when custom/built-in elements isn't 
-       supported in the browser). */ 
-       mapml-viewer:defined { 
-         /* Responsive map. */ 
-          max-width: 100%;  
-          
-         /* Full viewport. */ 
-          width: 100%;  
-          height: 100%;  
-          
-         /* Remove default (native-like) border. */ 
-         /* border: none; */ 
-       } 
-        
-       /* Pre-style to avoid FOUC of inline layer- and fallback content. */ 
-       mapml-viewer:not(:defined) > * { 
-         display: none; 
-       } 
-       /* Ensure inline layer content is hidden if custom/built-in elements isn't 
-       supported, or if javascript is disabled. This needs to be defined separately 
-       from the above, because the `:not(:defined)` selector invalidates the entire 
-       declaration in browsers that do not support it. */ 
-       layer- { 
-         display: none; 
-       } 
-     </style> 
-     <noscript> 
-       <style> 
-         /* Ensure fallback content (children of the map element) is displayed if 
-         custom/built-in elements is supported but javascript is disabled. */ 
-         mapml-viewer:not(:defined) > :not(layer-) { 
-           display: initial; 
-         } 
-       </style> 
-     </noscript> 
+    <link rel="stylesheet" href="../../global.css">
     <script type="module">
       let customProjectionDefinition = `{
             "projection": "ATLAS_POLAR_MAP",

--- a/custom-projections/bc/index.html
+++ b/custom-projections/bc/index.html
@@ -2,48 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>Province of British Columbia Albers tile cache</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Province of British Columbia Albers tile cache</title>
     <script type="module" src="../../dist/web-map.js"></script>
-    <style>
-      html,
-      body {
-        height: 100%;
-      }
-      * {
-        margin: 0;
-        padding: 0;
-      }
-      
-      /* Specifying the `:defined` selector is recommended to style the map
-      element, such that styles don't apply when fallback content is in use
-      (e.g. when scripting is disabled or when custom/built-in elements isn't
-      supported in the browser). */
-      map[is="web-map"]:defined {
-        /* Responsive map. */
-        /* max-width: 100%; */
-        
-        /* Full viewport. */
-         width: 100%; 
-         height: 100%; 
-        
-        /* Remove default (native-like) border. */
-        /* border: none; */
-      }
-      
-      /* Pre-style to avoid FOUC of inline layer- and fallback content. */
-      map[is="web-map"]:not(:defined) + img[usemap],
-      map[is="web-map"]:not(:defined) > :not(area):not(.mapml-web-map) {
-        display: none;
-      }
-      /* Ensure inline layer content is hidden if custom/built-in elements isn't
-      supported, or if javascript is disabled. This needs to be defined separately
-      from the above, because the `:not(:defined)` selector invalidates the entire
-      declaration in browsers that do not support it. */
-      layer- {
-        display: none;
-      }
-    </style>
+    <link rel="stylesheet" href="../../global.css">
     <script type="module">
     /* EPSG:3005 */
       let customProjectionDefinition = `{

--- a/global.css
+++ b/global.css
@@ -1,0 +1,48 @@
+*, ::before, ::after {
+  box-sizing: border-box;
+}
+
+html {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
+  line-height: 1.5;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+}
+
+
+/*
+ * map viewers
+ */
+[is="web-map"], mapml-viewer {
+  height: 100%;
+  max-width: 100%;
+  width: 100%;
+}
+/* https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/350#issuecomment-834466757 */
+[is="web-map"], mapml-viewer {
+  box-sizing: inherit;
+}
+/* Ensure inline layer content is hidden if custom/built-in elements isn't
+supported, or if javascript is disabled. This needs to be defined separately
+from the above, because the `:not(:defined)` selector invalidates the entire
+declaration in browsers that do not support it. */
+layer- {
+ display: none;
+}
+/* Pre-style to avoid FOUC of inline layer- and fallback content. */
+mapml-viewer:not(:defined) + img[usemap],
+mapml-viewer:not(:defined) > :not(area):not(.mapml-web-map) {
+  display: none;
+}
+/* Pre-style to avoid FOUC of inline layer- and fallback content. */
+[is="web-map"]:not(:defined) + img[usemap],
+[is="web-map"]:not(:defined) > :not(area):not(.mapml-web-map) {
+  display: none;
+}

--- a/index.html
+++ b/index.html
@@ -4,42 +4,38 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <title>Examples and Experiments</title>
-     <style> 
-       html,
-       body {
-         height: 100%;
-       }
-       body {
-         margin: 20px;
-       }
-       *, ::before, ::after {
-         box-sizing: border-box;
-       }
-       a {display: block}
-      * {
-          font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji;
-          font-size: 16px;
-          line-height: 1.5;
-          word-wrap: break-word;
+    <link rel="stylesheet" href="global.css">
+    <style>
+      body {
+       padding: 0 1rem;
       }
-     </style> 
+      a {
+       display: block;
+      }
+    </style>
   </head>
   <body>
-    <section>
-      <h3>Screenreader / accessibility validation</h3>
-    <a href="screenreader/restaurants/">Restaurant locations in Ottawa</a>
-    <a href="painting/">Non-geographic image map</a>
-    </section>
-    <section id="georeferencing-api">
-      <h3>Custom Projections aka the Georeferencing API</h3>
-      <a href="custom-projections/Arctic-SDI/">Lambert Equal Area Azimuthal - laea</a>
-      <a href="custom-projections/Atlas-of-Canada/">Atlas of Canada Polar Wall Map - aeqd</a>
-      <a href="custom-projections/bc/">British Columbia Albers Equal Area</a>
+    <main>
+      <h1>Experiments</h1>
+      
+      <section>
+        <h2>Screenreader / accessibility validation</h2>
+        <a href="screenreader/restaurants/">Restaurant locations in Ottawa</a>
+        <a href="painting/">Non-geographic image map</a>
+      </section>
+      
+      <section id="georeferencing-api">
+        <h2>Custom Projections aka the Georeferencing API</h2>
+        <a href="custom-projections/Arctic-SDI/">Lambert Equal Area Azimuthal - laea</a>
+        <a href="custom-projections/Atlas-of-Canada/">Atlas of Canada Polar Wall Map - aeqd</a>
+        <a href="custom-projections/bc/">British Columbia Albers Equal Area</a>
         <a href="change-projection/zoomin-zoomout/mapml-viewer/">Change projection on zoom change</a>
-    </section>
-    <section>
-      <h3>Vector tiles</h3>
+      </section>
+      
+      <section>
+        <h2>Vector tiles</h2>
         <a href="vector-tiles/mapml/mapml-viewer/">MapML vector tiles styled with external CSS stylesheet</a>
-    </section>
+      </section>
+    </main>
   </body>
 </html>

--- a/painting/index.html
+++ b/painting/index.html
@@ -1,65 +1,26 @@
 <!DOCTYPE html>
-<html>
-    <head>
-        <title>Painting Example</title>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width,initial-scale=1">
-        <script type="module" src="../dist/mapml-viewer.js"></script>
-        <style> 
-          html, 
-          body { 
-            height: 100%; 
-          }
-
-          /* Specifying the `:defined` selector is recommended to style the map 
-          element, such that styles don't apply when fallback content is in use 
-          (e.g. when scripting is disabled or when custom/built-in elements isn't 
-          supported in the browser). */ 
-          mapml-viewer:defined { 
-            /* Responsive map. */ 
-             max-width: 100%;  
-
-             width: 100%;  
-             height: 80%;  
-
-            /* Remove default (native-like) border. */ 
-            /* border: none; */ 
-          } 
-
-          /* Pre-style to avoid FOUC of inline layer- and fallback content. */ 
-          mapml-viewer:not(:defined) > * { 
-            display: none; 
-          } 
-          /* Ensure inline layer content is hidden if custom/built-in elements isn't 
-          supported, or if javascript is disabled. This needs to be defined separately 
-          from the above, because the `:not(:defined)` selector invalidates the entire 
-          declaration in browsers that do not support it. */ 
-          layer- { 
-            display: none; 
-          } 
-        </style> 
-        <noscript> 
-          <style> 
-            /* Ensure fallback content (children of the map element) is displayed if 
-            custom/built-in elements is supported but javascript is disabled. */ 
-            mapml-viewer:not(:defined) > :not(layer-) { 
-              display: initial; 
-            } 
-          </style> 
-        </noscript> 
-        <style>
-          .map-a {fill: green}
-        </style>
-    </head>
-    <body>
-          <style>
-      * {
-          font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji;
-          font-size: 16px;
-          line-height: 1.5;
-          word-wrap: break-word;
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Painting Example</title>
+    <script type="module" src="../dist/mapml-viewer.js"></script>
+    <link rel="stylesheet" href="../global.css">
+    <style>
+      body {
+        padding: 0 1rem;
+      }
+      mapml-viewer:defined {
+       height: 65%;
       }
     </style>
+    <style>
+      .map-a {
+        fill: green;
+      }
+    </style>
+  </head>
+  <body>
       <p>This example illustrates a few features of the Web-Map-Custom-Element mapml-viewer, as well as some concepts from MapML that it supports:</p>
       <ul>
         <li>Making whole features into map links: &lt;geometry&gt;&lt;map-a href="..."&gt;...&lt;/map-a&gt;&lt;/geometry&gt;</li>

--- a/screenreader/display/index.html
+++ b/screenreader/display/index.html
@@ -5,44 +5,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <title>Ottawa Restaurants Map with display: none eliminated</title>
     <script type="module" src="../role-with-display/dist/mapml-viewer.js"></script>
-     <style> 
-       html,
-       body {
-         height: 100%;
-       }
-       body {
-         margin: 0;
-       }
-       *, ::before, ::after {
-         box-sizing: border-box;
-       }
-        
-       /* Specifying the `:defined` selector is recommended to style the map 
-       element, such that styles don't apply when fallback content is in use 
-       (e.g. when scripting is disabled or when custom/built-in elements isn't 
-       supported in the browser). */ 
-       mapml-viewer:defined { 
-         /* Responsive map. */ 
-          max-width: 100%;  
-          
-         /* Full viewport. */ 
-          width: 100%;  
-          height: 100%;  
-          
-         /* Remove default (native-like) border. */ 
-         /* border: none; */ 
-       } 
-        
-     </style> 
-     <noscript> 
-       <style> 
-         /* Ensure fallback content (children of the map element) is displayed if 
-         custom/built-in elements is supported but javascript is disabled. */ 
-         mapml-viewer:not(:defined) > :not(layer-) { 
-           display: initial; 
-         } 
-       </style> 
-     </noscript> 
+    <link rel="stylesheet" href="../../global.css">
   </head>
   <body>
     <mapml-viewer aria-label="Map with display: none eliminated" projection="CBMTILE" zoom="17" lat="45.4069740362364" lon="-75.70155300710053" >

--- a/screenreader/original/index.html
+++ b/screenreader/original/index.html
@@ -5,55 +5,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <title>Ottawa Restaurants The original unchanged and problematic version</title>
     <script type="module" src="../../dist/mapml-viewer.js"></script>
-     <style> 
-       html,
-       body {
-         height: 100%;
-       }
-       body {
-         margin: 0;
-       }
-       *, ::before, ::after {
-         box-sizing: border-box;
-       }
-        
-       /* Specifying the `:defined` selector is recommended to style the map 
-       element, such that styles don't apply when fallback content is in use 
-       (e.g. when scripting is disabled or when custom/built-in elements isn't 
-       supported in the browser). */ 
-       mapml-viewer:defined { 
-         /* Responsive map. */ 
-          max-width: 100%;  
-          
-         /* Full viewport. */ 
-          width: 100%;  
-          height: 100%;  
-          
-         /* Remove default (native-like) border. */ 
-         /* border: none; */ 
-       } 
-        
-       /* Pre-style to avoid FOUC of inline layer- and fallback content. */ 
-       mapml-viewer:not(:defined) > * { 
-         display: none; 
-       } 
-       /* Ensure inline layer content is hidden if custom/built-in elements isn't 
-       supported, or if javascript is disabled. This needs to be defined separately 
-       from the above, because the `:not(:defined)` selector invalidates the entire 
-       declaration in browsers that do not support it. */ 
-       layer- { 
-         display: none; 
-       } 
-     </style> 
-     <noscript> 
-       <style> 
-         /* Ensure fallback content (children of the map element) is displayed if 
-         custom/built-in elements is supported but javascript is disabled. */ 
-         mapml-viewer:not(:defined) > :not(layer-) { 
-           display: initial; 
-         } 
-       </style> 
-     </noscript> 
+    <link rel="stylesheet" href="../../global.css">
   </head>
   <body>
     <mapml-viewer projection="CBMTILE" zoom="17" lat="45.4069740362364" lon="-75.70155300710053" >

--- a/screenreader/restaurants/index.html
+++ b/screenreader/restaurants/index.html
@@ -5,55 +5,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <title>Ottawa Restaurants</title>
     <script type="module" src="../../dist/mapml-viewer.js"></script>
-     <style> 
-       html,
-       body {
-         height: 100%;
-       }
-       body {
-         margin: 0;
-       }
-       *, ::before, ::after {
-         box-sizing: border-box;
-       }
-        
-       /* Specifying the `:defined` selector is recommended to style the map 
-       element, such that styles don't apply when fallback content is in use 
-       (e.g. when scripting is disabled or when custom/built-in elements isn't 
-       supported in the browser). */ 
-       mapml-viewer:defined { 
-         /* Responsive map. */ 
-          max-width: 100%;  
-          
-         /* Full viewport. */ 
-          width: 100%;  
-          height: 100%;  
-          
-         /* Remove default (native-like) border. */ 
-         /* border: none; */ 
-       } 
-        
-       /* Pre-style to avoid FOUC of inline layer- and fallback content. */ 
-       mapml-viewer:not(:defined) > * { 
-         display: none; 
-       } 
-       /* Ensure inline layer content is hidden if custom/built-in elements isn't 
-       supported, or if javascript is disabled. This needs to be defined separately 
-       from the above, because the `:not(:defined)` selector invalidates the entire 
-       declaration in browsers that do not support it. */ 
-       layer- { 
-         display: none; 
-       } 
-     </style> 
-     <noscript> 
-       <style> 
-         /* Ensure fallback content (children of the map element) is displayed if 
-         custom/built-in elements is supported but javascript is disabled. */ 
-         mapml-viewer:not(:defined) > :not(layer-) { 
-           display: initial; 
-         } 
-       </style> 
-     </noscript> 
+    <link rel="stylesheet" href="../../global.css">
   </head>
   <body>
     <mapml-viewer projection="CBMTILE" zoom="17" lat="45.4069740362364" lon="-75.70155300710053" >

--- a/screenreader/role-with-display/index.html
+++ b/screenreader/role-with-display/index.html
@@ -5,44 +5,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <title>Ottawa Restaurants with role=application and display: none eliminated</title>
     <script type="module" src="./dist/mapml-viewer.js"></script>
-     <style> 
-       html,
-       body {
-         height: 100%;
-       }
-       body {
-         margin: 0;
-       }
-       *, ::before, ::after {
-         box-sizing: border-box;
-       }
-        
-       /* Specifying the `:defined` selector is recommended to style the map 
-       element, such that styles don't apply when fallback content is in use 
-       (e.g. when scripting is disabled or when custom/built-in elements isn't 
-       supported in the browser). */ 
-       mapml-viewer:defined { 
-         /* Responsive map. */ 
-          max-width: 100%;  
-          
-         /* Full viewport. */ 
-          width: 100%;  
-          height: 100%;  
-          
-         /* Remove default (native-like) border. */ 
-         /* border: none; */ 
-       } 
-        
-     </style> 
-     <noscript> 
-       <style> 
-         /* Ensure fallback content (children of the map element) is displayed if 
-         custom/built-in elements is supported but javascript is disabled. */ 
-         mapml-viewer:not(:defined) > :not(layer-) { 
-           display: initial; 
-         } 
-       </style> 
-     </noscript> 
+    <link rel="stylesheet" href="../../global.css">
   </head>
   <body>
     <mapml-viewer role="application" projection="CBMTILE" zoom="17" lat="45.4069740362364" lon="-75.70155300710053" >

--- a/screenreader/role/index.html
+++ b/screenreader/role/index.html
@@ -5,55 +5,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <title>Ottawa Restaurants with the map viewer with role=application</title>
     <script type="module" src="../../dist/mapml-viewer.js"></script>
-     <style> 
-       html,
-       body {
-         height: 100%;
-       }
-       body {
-         margin: 0;
-       }
-       *, ::before, ::after {
-         box-sizing: border-box;
-       }
-        
-       /* Specifying the `:defined` selector is recommended to style the map 
-       element, such that styles don't apply when fallback content is in use 
-       (e.g. when scripting is disabled or when custom/built-in elements isn't 
-       supported in the browser). */ 
-       mapml-viewer:defined { 
-         /* Responsive map. */ 
-          max-width: 100%;  
-          
-         /* Full viewport. */ 
-          width: 100%;  
-          height: 100%;  
-          
-         /* Remove default (native-like) border. */ 
-         /* border: none; */ 
-       } 
-        
-       /* Pre-style to avoid FOUC of inline layer- and fallback content. */ 
-       mapml-viewer:not(:defined) > * { 
-         display: none; 
-       } 
-       /* Ensure inline layer content is hidden if custom/built-in elements isn't 
-       supported, or if javascript is disabled. This needs to be defined separately 
-       from the above, because the `:not(:defined)` selector invalidates the entire 
-       declaration in browsers that do not support it. */ 
-       layer- { 
-         display: none; 
-       } 
-     </style> 
-     <noscript> 
-       <style> 
-         /* Ensure fallback content (children of the map element) is displayed if 
-         custom/built-in elements is supported but javascript is disabled. */ 
-         mapml-viewer:not(:defined) > :not(layer-) { 
-           display: initial; 
-         } 
-       </style> 
-     </noscript> 
+    <link rel="stylesheet" href="../../global.css">
   </head>
   <body>
     <mapml-viewer role="application" projection="CBMTILE" zoom="17" lat="45.4069740362364" lon="-75.70155300710053" >

--- a/vector-tiles/mapml/mapml-viewer/index.html
+++ b/vector-tiles/mapml/mapml-viewer/index.html
@@ -1,50 +1,23 @@
 <!DOCTYPE html>
-<html>
-    <head>
-        <title>MapML Vector Tiles</title>
-        <meta name="viewport" content="width=device-width,initial-scale=1">
-        <meta charset="UTF-8">
-            <script type="module" src="../../../dist/mapml-viewer.js"></script>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>MapML Vector Tiles</title>
+    <script type="module" src="../../../dist/mapml-viewer.js"></script>
+    <link rel="stylesheet" href="../../../global.css">
     <style>
-      html,
-      body {
-        height: 100%;
-      }
-      * {
-        margin: 0;
-        padding: 0;
-      }
-      
-      /* Specifying the `:defined` selector is recommended to style the map
-      element, such that styles don't apply when fallback content is in use
-      (e.g. when scripting is disabled or when custom/built-in elements isn't
-      supported in the browser). */
       mapml-viewer:defined {
-        /* Responsive map. */
-        /* max-width: 100%; */
-        
-        /* Full viewport. */
-         width: 100%; 
-         height: 50%; 
-        
-        /* Remove default (native-like) border. */
-        /* border: none; */
+        height: 50%;
+        border: 0;
+        vertical-align: middle;
       }
       
-      /* Pre-style to avoid FOUC of inline layer- and fallback content. */
-      mapml-viewer:not(:defined) + img[usemap],
-      mapml-viewer:not(:defined) > :not(area):not(.mapml-web-map) {
-        display: none;
-      }
-      /* Ensure inline layer content is hidden if custom/built-in elements isn't
-      supported, or if javascript is disabled. This needs to be defined separately
-      from the above, because the `:not(:defined)` selector invalidates the entire
-      declaration in browsers that do not support it. */
-      layer- {
-        display: none;
+      mapml-viewer:defined ~ mapml-viewer:defined {
+        border-top: 1px inset;
       }
     </style>
-    </head>
+  </head>
     <body>
       <mapml-viewer projection="WGS84" zoom="0" lat="0" lon="0" controls>
         <layer- label="Countries - WorldCRS84Quad" checked>

--- a/vector-tiles/mapml/web-map/index.html
+++ b/vector-tiles/mapml/web-map/index.html
@@ -1,47 +1,20 @@
 <!DOCTYPE html>
-<html>
-    <head>
-        <title>MapML Vector Tiles</title>
-        <meta name="viewport" content="width=device-width,initial-scale=1">
-        <meta charset="UTF-8">
-            <script type="module" src="../../../dist/web-map.js"></script>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>MapML Vector Tiles</title>
+    <script type="module" src="../../../dist/web-map.js"></script>
+    <link rel="stylesheet" href="../../../global.css">
     <style>
-      html,
-      body {
-        height: 100%;
-      }
-      * {
-        margin: 0;
-        padding: 0;
-      }
-      
-      /* Specifying the `:defined` selector is recommended to style the map
-      element, such that styles don't apply when fallback content is in use
-      (e.g. when scripting is disabled or when custom/built-in elements isn't
-      supported in the browser). */
       map[is="web-map"]:defined {
-        /* Responsive map. */
-        /* max-width: 100%; */
-        
-        /* Full viewport. */
-         width: 100%; 
-         height: 50%; 
-        
-        /* Remove default (native-like) border. */
-        /* border: none; */
+        height: 50%;
+        border: 0;
+        vertical-align: middle;
       }
       
-      /* Pre-style to avoid FOUC of inline layer- and fallback content. */
-      map[is="web-map"]:not(:defined) + img[usemap],
-      map[is="web-map"]:not(:defined) > :not(area):not(.mapml-web-map) {
-        display: none;
-      }
-      /* Ensure inline layer content is hidden if custom/built-in elements isn't
-      supported, or if javascript is disabled. This needs to be defined separately
-      from the above, because the `:not(:defined)` selector invalidates the entire
-      declaration in browsers that do not support it. */
-      layer- {
-        display: none;
+      map[is="web-map"]:defined ~ map[is="web-map"]:defined {
+        border-top: 1px inset;
       }
     </style>
     </head>


### PR DESCRIPTION
- [x] Adds a global.css with styles that apply to all maps and documents in general.
- [x] Removes borders as requested in https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/350.
- [x] Removes of use  `<noscript>` reset styles, because we're not using any fallback content for any of these maps. In Web-Map-Custom-Element this is used to show authors how/why to do so.
- [x] Moves use of inline pre-styles to global.css

