### PR TITLE
Correct styles for pre-styling `<mapml-viewer>`

### DIFF
--- a/global.css
+++ b/global.css
@@ -37,11 +37,9 @@ layer- {
  display: none;
 }
 /* Pre-style to avoid FOUC of inline layer- and fallback content. */
-mapml-viewer:not(:defined) + img[usemap],
-mapml-viewer:not(:defined) > :not(area):not(.mapml-web-map) {
+mapml-viewer:not(:defined) > * {
   display: none;
 }
-/* Pre-style to avoid FOUC of inline layer- and fallback content. */
 [is="web-map"]:not(:defined) + img[usemap],
 [is="web-map"]:not(:defined) > :not(area):not(.mapml-web-map) {
   display: none;


### PR DESCRIPTION
The global styles for the `<mapml-viewer>` element actually uses styles that only are applicable to `<map>`, probably a case of copy & paste and just renaming the element selector. The correct styles for `<mapml-viewer>` can be found here: https://github.com/Maps4HTML/Web-Map-Custom-Element/blob/ae0364098a43ccaa34b9ab4a42b82b5f34df52dd/index-mapml-viewer.html#L34-L54.

I probably need to write some sort of explainer for the reset styles, I don't think the comments are enough. 😋