### PR TITLE
Only apply styles if elements are `:defined`

### DIFF
--- a/global.css
+++ b/global.css
@@ -2,31 +2,28 @@
   box-sizing: border-box;
 }
 
-html {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
-  line-height: 1.5;
-}
-
 html,
 body {
   height: 100%;
 }
 
 body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
   margin: 0;
+  line-height: 1.5;
 }
 
 
 /*
  * map viewers
  */
-[is="web-map"], mapml-viewer {
+[is="web-map"]:defined, mapml-viewer:defined {
   height: 100%;
   max-width: 100%;
   width: 100%;
 }
 /* https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/350#issuecomment-834466757 */
-[is="web-map"], mapml-viewer {
+[is="web-map"]:defined, mapml-viewer:defined {
   box-sizing: inherit;
 }
 /* Ensure inline layer content is hidden if custom/built-in elements isn't


### PR DESCRIPTION
Adds `:defined` to the map viewer selectors. That's really only important if you expect to use fallback elements (Light DOM children) of the map viewers. But it's a better default, so lets use that.

&plus; other small optimization.