### PR TITLE
Add Sync Repositories badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Experiments
 
+![Sync Repositories](https://github.com/Maps4HTML/Web-Map-Custom-Element/workflows/Sync%20Repositories/badge.svg)
+
 Experiments are listed here: https://maps4html.org/experiments/index.html


### PR DESCRIPTION
As [this repo is synced](https://github.com/Maps4HTML/Web-Map-Custom-Element/blob/e1264b86b897bbdeb7a3dd2ff7da31c3d53aa313/.github/workflows/sync.yml#L52) with Web-Map-Custom-Element it may as well display the badge.