### PR TITLE
Remove scrollbars take 2

### DIFF
--- a/global.css
+++ b/global.css
@@ -21,6 +21,7 @@ body {
   height: 100%;
   max-width: 100%;
   width: 100%;
+  vertical-align: middle;
 }
 /* Ensure inline layer content is hidden if custom/built-in elements isn't
 supported, or if javascript is disabled. This needs to be defined separately

--- a/global.css
+++ b/global.css
@@ -22,10 +22,6 @@ body {
   max-width: 100%;
   width: 100%;
 }
-/* https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/350#issuecomment-834466757 */
-[is="web-map"]:defined, mapml-viewer:defined {
-  box-sizing: inherit;
-}
 /* Ensure inline layer content is hidden if custom/built-in elements isn't
 supported, or if javascript is disabled. This needs to be defined separately
 from the above, because the `:not(:defined)` selector invalidates the entire


### PR DESCRIPTION
This should also remove scrollbars in Firefox, which requires `vertical-align: middle`.

I think we can close out https://github.com/Maps4HTML/Web-Map-Custom-Element/issues/350 now.