### PR TITLE
Correct remaining HTML namespace declarations...

### DIFF
--- a/custom-projections/Arctic-SDI/links.xsl
+++ b/custom-projections/Arctic-SDI/links.xsl
@@ -1,12 +1,12 @@
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-                xmlns:h="http://www.w3.org/1999/xhtml/" xmlns="http://www.w3.org/1999/xhtml" exclude-result-prefixes="h html">
+                xmlns:h="http://www.w3.org/1999/xhtml" xmlns="http://www.w3.org/1999/xhtml" exclude-result-prefixes="h html">
   <xsl:output omit-xml-declaration="yes"/>
   <xsl:template match="node() | @*">
     <xsl:copy>
       <xsl:apply-templates select="node() | @*"/>
     </xsl:copy>
   </xsl:template>
-  <xsl:template  match="h:head/node()[position()=last()]" xpath-default-namespace="http://www.w3.org/1999/xhtml/" >
+  <xsl:template  match="h:head/node()[position()=last()]" xpath-default-namespace="http://www.w3.org/1999/xhtml" >
     <xsl:copy>
       <xsl:apply-templates select="node() | @*"/>
     </xsl:copy>


### PR DESCRIPTION
I must've missed these instances when correcting namespace declarations for this repo in https://github.com/Maps4HTML/experiments/pull/54.

I did an organization wide search for these declarations. This and https://github.com/Maps4HTML/pygeoapi-mapml-formatter/pull/1 should hopefully mean that there are no more HTML namespace declarations to _update_ (although there are many `<mapml>` elements without the declaration, to be done I guess).