### PR TITLE
Fix padding issue in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <style>
       body {
        padding: 1rem;
+       height: unset;
       }
       .example li { 
         list-style-type: none


### PR DESCRIPTION
Unsets the `height` inherited from global.css in index.html so that the declared padding applies correctly.

(Scroll down to bottom at https://maps4html.org/experiments/ to see the issue, should have 1rem padding.)