### PR TITLE
Add Internationalization / Localization section + `dir="rtl"` map

### DIFF
--- a/i18n/rtl/index.html
+++ b/i18n/rtl/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Right-to-left text (Ottawa Restaurants)</title>
+    <script type="module" src="../../dist/mapml-viewer.js"></script>
+    <link rel="stylesheet" href="../../global.css">
+  </head>
+  <body>
+    <mapml-viewer dir="rtl" projection="CBMTILE" zoom="17" lat="45.4069740362364" lon="-75.70155300710053" controls>
+      <layer- label="CBMT" src="https://geogratis.gc.ca/mapml/en/cbmtile/cbmt/" checked></layer->
+      <layer- label="Ottawa Restaurants" src="restaurants.mapml" checked></layer->
+    </mapml-viewer>
+  </body>
+</html>

--- a/i18n/rtl/restaurants.mapml
+++ b/i18n/rtl/restaurants.mapml
@@ -1,0 +1,386 @@
+<mapml xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>Restaurants</title>
+        <meta charset="utf-8" />
+        <meta content="text/mapml" http-equiv="Content-Type" />
+        <link rel="license" href="http://opendatacommons.org/licenses/odbl/1-0/" title="© OpenStreetMap and contributors" />
+        <meta name="projection" content="CBMTILE"/>
+        <meta name="zoom" content="min=0,max=22,value=3" />
+        <meta name="cs" content="gcrs" />
+        <meta name="extent" content="top-left-easting=1509080.1964270622,top-left-northing=-169400.558801122,bottom-right-easting=1512094.3357886747,bottom-right-northing=-172702.5654051304" />
+    </head>
+    <body>
+        <feature id="restaurant_point.77" class="restaurant_point">
+          <featurecaption>Hung Sum Restaurant</featurecaption>
+            <geometry>
+                <point>
+                        <coordinates>-75.71543400037297 45.40819502909854</coordinates>
+                </point>
+            </geometry>
+            <properties>
+                <table>
+                    <thead>
+                        <tr>
+                            <th role="columnheader" scope="col">Property name</th>
+                            <th role="columnheader" scope="col">Property value</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th scope="row">amenity</th>
+                            <td itemprop="amenity">restaurant</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">name</th>
+                            <td itemprop="name">Hung Sum Restaurant</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">addr_stree</th>
+                            <td itemprop="addr_stree">Somerset Street West</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">addr_house</th>
+                            <td itemprop="addr_house">939</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">cuisine</th>
+                            <td itemprop="cuisine">chinese</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </properties>
+        </feature>
+        <feature id="restaurant_point.2" class="restaurant_point">
+          <featurecaption>Big Daddy's</featurecaption>
+            <geometry>
+                <point>
+                  <coordinates>-75.6902755031953 45.41868067160079</coordinates>
+                </point>
+            </geometry>
+            <properties>
+                <table>
+                    <thead>
+                        <tr>
+                            <th role="columnheader" scope="col">Property name</th>
+                            <th role="columnheader" scope="col">Property value</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th scope="row">amenity</th>
+                            <td itemprop="amenity">restaurant</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">name</th>
+                            <td itemprop="name">Big Daddy's</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">addr_stree</th>
+                            <td itemprop="addr_stree">Cooper Street</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">addr_house</th>
+                            <td itemprop="addr_house">180</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">cuisine</th>
+                            <td itemprop="cuisine">seafood</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </properties>
+        </feature>
+        <feature id="restaurant_point.9" class="restaurant_point">
+          <featurecaption>Hareg Cafe &amp; Variety</featurecaption>
+            <geometry>
+              <point>
+                <coordinates>-75.69108408413759 45.407905135087496</coordinates>
+              </point>
+            </geometry>
+            <properties>
+                <table>
+                    <thead>
+                        <tr>
+                            <th role="columnheader" scope="col">Property name</th>
+                            <th role="columnheader" scope="col">Property value</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th scope="row">amenity</th>
+                            <td itemprop="amenity">restaurant</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">name</th>
+                            <td itemprop="name">Hareg Cafe &amp; Variety</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">addr_stree</th>
+                            <td itemprop="addr_stree">Bank Street</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">addr_house</th>
+                            <td itemprop="addr_house">587</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">cuisine</th>
+                            <td itemprop="cuisine">african</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </properties>
+        </feature>
+        <feature id="restaurant_point.13" class="restaurant_point">
+          <featurecaption>Phucket Royal</featurecaption>
+            <geometry>
+              <point>
+                <coordinates>-75.70786179432208 45.410746385011166</coordinates>
+              </point>
+            </geometry>
+            <properties>
+                <table>
+                    <thead>
+                        <tr>
+                            <th role="columnheader" scope="col">Property name</th>
+                            <th role="columnheader" scope="col">Property value</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th scope="row">amenity</th>
+                            <td itemprop="amenity">restaurant</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">name</th>
+                            <td itemprop="name">Phucket Royal</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">addr_stree</th>
+                            <td itemprop="addr_stree">Somerset Street West</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">addr_house</th>
+                            <td itemprop="addr_house">713</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">cuisine</th>
+                            <td itemprop="cuisine">thai</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </properties>
+        </feature>
+        <feature id="restaurant_point.18" class="restaurant_point">
+          <featurecaption>Sushi 88</featurecaption>
+            <geometry>
+              <point>
+                <coordinates>-75.70642921479893 45.41108327733854</coordinates>
+              </point>
+            </geometry>
+            <properties>
+                <table>
+                    <thead>
+                        <tr>
+                            <th role="columnheader" scope="col">Property name</th>
+                            <th role="columnheader" scope="col">Property value</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th scope="row">amenity</th>
+                            <td itemprop="amenity">restaurant</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">name</th>
+                            <td itemprop="name">Sushi 88</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">addr_stree</th>
+                            <td itemprop="addr_stree">Somerset Street West</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">addr_house</th>
+                            <td itemprop="addr_house">690 B</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">cuisine</th>
+                            <td itemprop="cuisine">sushi</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">website</th>
+                            <td itemprop="website" />
+                        </tr>
+                        <tr>
+                            <th scope="row">phone</th>
+                            <td itemprop="phone">+1-613-233-3288</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">wheelchair</th>
+                            <td itemprop="wheelchair">no</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">addr_postc</th>
+                            <td itemprop="addr_postc">K1R 6P4</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">outdoor_se</th>
+                            <td itemprop="outdoor_se">no</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">takeaway</th>
+                            <td itemprop="takeaway">yes</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">delivery</th>
+                            <td itemprop="delivery">no</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">internet_a</th>
+                            <td itemprop="internet_a">no</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </properties>
+        </feature>
+        <feature id="restaurant_polygon.2" class="restaurant_polygon">
+          <featurecaption>Banditos</featurecaption>
+            <geometry>
+              <point>
+                  <coordinates>-75.689609 45.405803</coordinates>
+              </point>
+            </geometry>
+            <properties>
+                <table>
+                    <thead>
+                        <tr>
+                            <th role="columnheader" scope="col">Property name</th>
+                            <th role="columnheader" scope="col">Property value</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th scope="row">addr_house</th>
+                            <td itemprop="addr_house">683</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">addr_stree</th>
+                            <td itemprop="addr_stree">Bank Street</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">amenity</th>
+                            <td itemprop="amenity">restaurant</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">building</th>
+                            <td itemprop="building">commercial</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">name</th>
+                            <td itemprop="name">Banditos</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">cuisine</th>
+                            <td itemprop="cuisine">mexican</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </properties>
+        </feature>
+        <feature id="restaurant_polygon.7" class="restaurant_polygon">
+          <featurecaption>India Palace</featurecaption>
+            <geometry>
+              <point>
+                  <coordinates>-75.7019048 45.4191548</coordinates>
+              </point>
+            </geometry>
+            <properties>
+                <table>
+                    <thead>
+                        <tr>
+                            <th role="columnheader" scope="col">Property name</th>
+                            <th role="columnheader" scope="col">Property value</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th scope="row">addr_house</th>
+                            <td itemprop="addr_house">292</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">addr_stree</th>
+                            <td itemprop="addr_stree">Albert Street</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">amenity</th>
+                            <td itemprop="amenity">restaurant</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">building</th>
+                            <td itemprop="building">yes</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">name</th>
+                            <td itemprop="name">India Palace</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">cuisine</th>
+                            <td itemprop="cuisine">indian</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">website</th>
+                            <td itemprop="website">http://www.indiapalace.ca</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">phone</th>
+                            <td itemprop="phone">+1-613-234-5433</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </properties>
+        </feature>
+        <feature id="restaurant_polygon.20" class="restaurant_polygon">
+          <featurecaption>The Prescott</featurecaption>
+            <geometry>
+              <point>
+                  <coordinates>-75.7093517 45.4005727</coordinates>
+              </point>
+            </geometry>
+            <properties>
+                <table>
+                    <thead>
+                        <tr>
+                            <th role="columnheader" scope="col">Property name</th>
+                            <th role="columnheader" scope="col">Property value</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th scope="row">addr_house</th>
+                            <td itemprop="addr_house">379</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">addr_stree</th>
+                            <td itemprop="addr_stree">Preston Street</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">amenity</th>
+                            <td itemprop="amenity">restaurant</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">building</th>
+                            <td itemprop="building">retail</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">name</th>
+                            <td itemprop="name">The Prescott</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">website</th>
+                            <td itemprop="website"><a href="http://www.theprescott.com/">The Prescott</a></td>
+                        </tr>
+                    </tbody>
+                </table>
+            </properties>
+        </feature>
+    </body>
+</mapml>

--- a/index.html
+++ b/index.html
@@ -29,11 +29,18 @@
       <h1>Experiments</h1>
       
       <section>
-        <h2>Screenreader / accessibility validation</h2>
+        <h2>Screenreader / Accessibility validation</h2>
       <ul class="example">
         <li><a href="screenreader/restaurants/">Restaurant locations in Ottawa</a>
         <li><a href="painting/">Non-geographic image map</a>
       </ul>
+      </section>
+      
+      <section>
+        <h2>Internationalization / Localization validation</h2>
+        <ul class="example">
+          <li><a href="i18n/rtl/">Right-to-left text</a>
+        </ul>
       </section>
       
       <section id="georeferencing-api">


### PR DESCRIPTION
New section for [i18n](https://github.com/Maps4HTML/Web-Map-Custom-Element/issues?q=is%3Aissue+is%3Aopen+label%3Ai18n) validation. Also adds a map (Ottawa Restaurants) with right-to-left text direction.

Other things to add later include maps with a different [`writing-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/writing-mode), [`text-orientation`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-orientation), etc.