### PR TITLE
Correct a few HTML document titles

### DIFF
--- a/custom-projections/Atlas-of-Canada/index.html
+++ b/custom-projections/Atlas-of-Canada/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <map-title>Atlas of Canada Azimuthal Equal Distance Wall map</map-title>
+    <title>Atlas of Canada Azimuthal Equal Distance Wall map</title>
     <script type="module" src="../../dist/mapml-viewer.js"></script>
     <link rel="stylesheet" href="../../global.css">
     <script type="module">

--- a/custom-projections/BNG/index.html
+++ b/custom-projections/BNG/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <map-title>British National Grid custom projection</map-title>
+    <title>British National Grid custom projection</title>
     <script type="module" src="../../dist/mapml-viewer.js"></script>
     <link rel="stylesheet" href="../../global.css">
     <!-- 

--- a/datacube/index.html
+++ b/datacube/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width,initial-scale=1">
-        <map-title>Minimum Snow and Ice</map-title>
+        <title>Minimum Snow and Ice</title>
         <script type="module" src="../dist/mapml-viewer.js"></script>
         <link rel="stylesheet" href="../global.css">
     </head>


### PR DESCRIPTION
Fix _HTML document_ titles that were accidentally changed to `<map-title>` in https://github.com/Maps4HTML/experiments/pull/61.