### PR TITLE
Update i18n/rtl/restaurants.mapml to use custom elements

### DIFF
--- a/i18n/rtl/restaurants.mapml
+++ b/i18n/rtl/restaurants.mapml
@@ -1,23 +1,23 @@
-<mapml xmlns="http://www.w3.org/1999/xhtml">
-    <head>
-        <title>Restaurants</title>
-        <meta charset="utf-8" />
-        <meta content="text/mapml" http-equiv="Content-Type" />
-        <link rel="license" href="http://opendatacommons.org/licenses/odbl/1-0/" title="© OpenStreetMap and contributors" />
-        <meta name="projection" content="CBMTILE"/>
-        <meta name="zoom" content="min=0,max=22,value=3" />
-        <meta name="cs" content="gcrs" />
-        <meta name="extent" content="top-left-easting=1509080.1964270622,top-left-northing=-169400.558801122,bottom-right-easting=1512094.3357886747,bottom-right-northing=-172702.5654051304" />
-    </head>
-    <body>
-        <feature id="restaurant_point.77" class="restaurant_point">
-          <featurecaption>Hung Sum Restaurant</featurecaption>
-            <geometry>
-                <point>
-                        <coordinates>-75.71543400037297 45.40819502909854</coordinates>
-                </point>
-            </geometry>
-            <properties>
+<mapml- xmlns="http://www.w3.org/1999/xhtml">
+    <map-head>
+        <map-title>Restaurants</map-title>
+        <map-meta charset="utf-8" ></map-meta>
+        <map-meta content="text/mapml" http-equiv="Content-Type" ></map-meta>
+        <map-link rel="license" href="http://opendatacommons.org/licenses/odbl/1-0/" title="© OpenStreetMap and contributors" />
+        <map-meta name="projection" content="CBMTILE"></map-meta>
+        <map-meta name="zoom" content="min=0,max=22,value=3" ></map-meta>
+        <map-meta name="cs" content="gcrs" ></map-meta>
+        <map-meta name="extent" content="top-left-easting=1509080.1964270622,top-left-northing=-169400.558801122,bottom-right-easting=1512094.3357886747,bottom-right-northing=-172702.5654051304" ></map-meta>
+    </map-head>
+    <map-body>
+        <map-feature id="restaurant_map-point.77" class="restaurant_map-point">
+          <map-featurecaption>Hung Sum Restaurant</map-featurecaption>
+            <map-geometry>
+                <map-point>
+                        <map-coordinates>-75.71543400037297 45.40819502909854</map-coordinates>
+                </map-point>
+            </map-geometry>
+            <map-properties>
                 <table>
                     <thead>
                         <tr>
@@ -48,16 +48,16 @@
                         </tr>
                     </tbody>
                 </table>
-            </properties>
-        </feature>
-        <feature id="restaurant_point.2" class="restaurant_point">
-          <featurecaption>Big Daddy's</featurecaption>
-            <geometry>
-                <point>
-                  <coordinates>-75.6902755031953 45.41868067160079</coordinates>
-                </point>
-            </geometry>
-            <properties>
+            </map-properties>
+        </map-feature>
+        <map-feature id="restaurant_map-point.2" class="restaurant_map-point">
+          <map-featurecaption>Big Daddy's</map-featurecaption>
+            <map-geometry>
+                <map-point>
+                  <map-coordinates>-75.6902755031953 45.41868067160079</map-coordinates>
+                </map-point>
+            </map-geometry>
+            <map-properties>
                 <table>
                     <thead>
                         <tr>
@@ -88,16 +88,16 @@
                         </tr>
                     </tbody>
                 </table>
-            </properties>
-        </feature>
-        <feature id="restaurant_point.9" class="restaurant_point">
-          <featurecaption>Hareg Cafe &amp; Variety</featurecaption>
-            <geometry>
-              <point>
-                <coordinates>-75.69108408413759 45.407905135087496</coordinates>
-              </point>
-            </geometry>
-            <properties>
+            </map-properties>
+        </map-feature>
+        <map-feature id="restaurant_map-point.9" class="restaurant_map-point">
+          <map-featurecaption>Hareg Cafe &amp; Variety</map-featurecaption>
+            <map-geometry>
+              <map-point>
+                <map-coordinates>-75.69108408413759 45.407905135087496</map-coordinates>
+              </map-point>
+            </map-geometry>
+            <map-properties>
                 <table>
                     <thead>
                         <tr>
@@ -128,16 +128,16 @@
                         </tr>
                     </tbody>
                 </table>
-            </properties>
-        </feature>
-        <feature id="restaurant_point.13" class="restaurant_point">
-          <featurecaption>Phucket Royal</featurecaption>
-            <geometry>
-              <point>
-                <coordinates>-75.70786179432208 45.410746385011166</coordinates>
-              </point>
-            </geometry>
-            <properties>
+            </map-properties>
+        </map-feature>
+        <map-feature id="restaurant_map-point.13" class="restaurant_map-point">
+          <map-featurecaption>Phucket Royal</map-featurecaption>
+            <map-geometry>
+              <map-point>
+                <map-coordinates>-75.70786179432208 45.410746385011166</map-coordinates>
+              </map-point>
+            </map-geometry>
+            <map-properties>
                 <table>
                     <thead>
                         <tr>
@@ -168,16 +168,16 @@
                         </tr>
                     </tbody>
                 </table>
-            </properties>
-        </feature>
-        <feature id="restaurant_point.18" class="restaurant_point">
-          <featurecaption>Sushi 88</featurecaption>
-            <geometry>
-              <point>
-                <coordinates>-75.70642921479893 45.41108327733854</coordinates>
-              </point>
-            </geometry>
-            <properties>
+            </map-properties>
+        </map-feature>
+        <map-feature id="restaurant_map-point.18" class="restaurant_map-point">
+          <map-featurecaption>Sushi 88</map-featurecaption>
+            <map-geometry>
+              <map-point>
+                <map-coordinates>-75.70642921479893 45.41108327733854</map-coordinates>
+              </map-point>
+            </map-geometry>
+            <map-properties>
                 <table>
                     <thead>
                         <tr>
@@ -240,16 +240,16 @@
                         </tr>
                     </tbody>
                 </table>
-            </properties>
-        </feature>
-        <feature id="restaurant_polygon.2" class="restaurant_polygon">
-          <featurecaption>Banditos</featurecaption>
-            <geometry>
-              <point>
-                  <coordinates>-75.689609 45.405803</coordinates>
-              </point>
-            </geometry>
-            <properties>
+            </map-properties>
+        </map-feature>
+        <map-feature id="restaurant_polygon.2" class="restaurant_polygon">
+          <map-featurecaption>Banditos</map-featurecaption>
+            <map-geometry>
+              <map-point>
+                  <map-coordinates>-75.689609 45.405803</map-coordinates>
+              </map-point>
+            </map-geometry>
+            <map-properties>
                 <table>
                     <thead>
                         <tr>
@@ -284,16 +284,16 @@
                         </tr>
                     </tbody>
                 </table>
-            </properties>
-        </feature>
-        <feature id="restaurant_polygon.7" class="restaurant_polygon">
-          <featurecaption>India Palace</featurecaption>
-            <geometry>
-              <point>
-                  <coordinates>-75.7019048 45.4191548</coordinates>
-              </point>
-            </geometry>
-            <properties>
+            </map-properties>
+        </map-feature>
+        <map-feature id="restaurant_polygon.7" class="restaurant_polygon">
+          <map-featurecaption>India Palace</map-featurecaption>
+            <map-geometry>
+              <map-point>
+                  <map-coordinates>-75.7019048 45.4191548</map-coordinates>
+              </map-point>
+            </map-geometry>
+            <map-properties>
                 <table>
                     <thead>
                         <tr>
@@ -336,16 +336,16 @@
                         </tr>
                     </tbody>
                 </table>
-            </properties>
-        </feature>
-        <feature id="restaurant_polygon.20" class="restaurant_polygon">
-          <featurecaption>The Prescott</featurecaption>
-            <geometry>
-              <point>
-                  <coordinates>-75.7093517 45.4005727</coordinates>
-              </point>
-            </geometry>
-            <properties>
+            </map-properties>
+        </map-feature>
+        <map-feature id="restaurant_polygon.20" class="restaurant_polygon">
+          <map-featurecaption>The Prescott</map-featurecaption>
+            <map-geometry>
+              <map-point>
+                  <map-coordinates>-75.7093517 45.4005727</map-coordinates>
+              </map-point>
+            </map-geometry>
+            <map-properties>
                 <table>
                     <thead>
                         <tr>
@@ -380,7 +380,7 @@
                         </tr>
                     </tbody>
                 </table>
-            </properties>
-        </feature>
-    </body>
-</mapml>
+            </map-properties>
+        </map-feature>
+    </map-body>
+</mapml->


### PR DESCRIPTION
Per https://github.com/Maps4HTML/experiments/issues/63:

> Elements in other files such as [i18n/rtl/restaurants.mapml](https://github.com/Maps4HTML/experiments/blob/cf534fa89d3c83fa325409fe4c7f21708719e61a/i18n/rtl/restaurants.mapml) were not changed in #61 and need to be converted too.