### PR TITLE
Update CSP hashes

### DIFF
--- a/security/csp/index.html
+++ b/security/csp/index.html
@@ -12,7 +12,7 @@
                 'sha256-nkSWviGEMA7GjEhvFalgIvhPJjztTxRSIg8+OvMVZnE='
                 'sha256-3rDMFlo5l2Wqdmy4qKaKncvyyzyt1OcMx8YhZIMhreY='
                 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='
-                'sha256-X+XHx4LwsOnum4QirdSF2fh3CJ7Epslfxl4MSSN4UWs=';
+                'sha256-rTznJl3tizDpoKt9XtMnDqQHkh5Nl013JQ61AgrUvBA=';
       connect-src 'self'
                   https://geogratis.gc.ca/mapml/;
       img-src 'self'
@@ -47,7 +47,7 @@
   'sha256-nkSWviGEMA7GjEhvFalgIvhPJjztTxRSIg8+OvMVZnE='
   'sha256-3rDMFlo5l2Wqdmy4qKaKncvyyzyt1OcMx8YhZIMhreY='
   'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='
-  'sha256-X+XHx4LwsOnum4QirdSF2fh3CJ7Epslfxl4MSSN4UWs=';
+  'sha256-rTznJl3tizDpoKt9XtMnDqQHkh5Nl013JQ61AgrUvBA=';
 <a href="https://w3c.github.io/webappsec-csp/#directive-connect-src">connect-src</a>
   'self'
   https://geogratis.gc.ca/mapml/;


### PR DESCRIPTION
Resolves console message:

```console
Refused to apply inline style because it violates the following Content Security Policy directive: "style-src 'self'
                'unsafe-hashes'
                'sha256-By15f3A82Q59ebVpTqYOcmdc5jVN4wai/iNm1ZDSCGY='
                'sha256-gWLDNLsycvRcRqEScFHdCYPrg1OzxzQBXX7qYFP1Ww0='
                'sha256-Yh21waoKFkXvfiGbkUMgTtK+WLTXPHnfAmHjd5VEOzs='
                'sha256-nkSWviGEMA7GjEhvFalgIvhPJjztTxRSIg8+OvMVZnE='
                'sha256-3rDMFlo5l2Wqdmy4qKaKncvyyzyt1OcMx8YhZIMhreY='
                'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='
                'sha256-X+XHx4LwsOnum4QirdSF2fh3CJ7Epslfxl4MSSN4UWs='".
Either the 'unsafe-inline' keyword, a hash ('sha256-rTznJl3tizDpoKt9XtMnDqQHkh5Nl013JQ61AgrUvBA='), or a nonce ('nonce-...') is required to enable inline execution.
```