### PR TITLE
Fix issue with standalone maps not always spanning the entire visible viewport

### DIFF
--- a/global.css
+++ b/global.css
@@ -13,6 +13,11 @@ body {
   line-height: 1.5;
 }
 
+body > mapml-viewer:only-child,
+body > [is="web-map"]:only-child {
+  position: fixed;
+}
+
 
 /*
  * map viewers


### PR DESCRIPTION
This is an attempt to prevent the gap below the map after exiting fullscreen:

<img width="250" src="https://user-images.githubusercontent.com/26493779/152803608-02d9c2c7-a7af-491b-81a4-3d06738b4a08.jpg">

by setting `position: fixed`, ref: https://developers.google.com/web/updates/2016/12/url-bar-resizing.