### PR TITLE
Add section IDs, bring back list styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,9 +10,6 @@
        padding: 1rem;
        height: unset;
       }
-      .example li { 
-        list-style-type: none
-      }
       .github-mark {
         display: block;
         width: max-content;
@@ -28,7 +25,7 @@
     <main>
       <h1>Experiments</h1>
       
-      <section>
+      <section id="a11y">
         <h2>Screenreader / Accessibility validation</h2>
       <ul class="example">
         <li><a href="screenreader/restaurants/">Restaurant locations in Ottawa</a>
@@ -39,14 +36,14 @@
       </ul>
       </section>
       
-      <section>
+      <section id="i18n">
         <h2>Internationalization / Localization validation</h2>
         <ul class="example">
           <li><a href="i18n/rtl/">Right-to-left text</a>
         </ul>
       </section>
       
-      <section>
+      <section id="priv-sec">
         <h2>Security / Privacy</h2>
         <ul class="example">
           <li><a href="security/csp/">CSP evaluation</a></li>
@@ -90,7 +87,7 @@
       </ul>
     </section>
       
-    <section>
+    <section id="misc">
       <h2>Miscellaneous</h2>
       <ul class="example">
         <li>Snow and Ice Probability: <a href="datacube/">Time Dimension &lt;select&gt;</a></li>


### PR DESCRIPTION
Some sections were missing IDs.

Also, I find it easier to distinguish the different examples with default list-styles, even if the text doesn't wrap.